### PR TITLE
Install `classie` instead of `desandro/classie`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ classie.toggle( element, 'my-class' ) // toggle class
 This script is a [Bower](https://github.com/twitter/bower) component.
 
 ``` bash
-bower install desandro/classie
+bower install classie
 ```


### PR DESCRIPTION
`desandro/classie` doesn’t return any results in Bower, so I registered your package under `classie`.
