### PR TITLE
Allowed specified third parameter to control toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ classie.has( element, 'my-class' ) // returns true/false
 classie.add( element, 'my-new-class' ) // add new class
 classie.remove( element, 'my-unwanted-class' ) // remove class
 classie.toggle( element, 'my-class' ) // toggle class
+classie.toggle( element, 'my-class', condition ) // toggle class based on condition
 ```
 
 ## Package management

--- a/classie.js
+++ b/classie.js
@@ -3,7 +3,7 @@
  * class helper functions
  * from bonzo https://github.com/ded/bonzo
  * MIT license
- * 
+ *
  * classie.has( elem, 'my-class' ) -> true/false
  * classie.add( elem, 'my-new-class' )
  * classie.remove( elem, 'my-unwanted-class' )
@@ -52,8 +52,9 @@ else {
   };
 }
 
-function toggleClass( elem, c ) {
-  var fn = hasClass( elem, c ) ? removeClass : addClass;
+function toggleClass( elem, c, state ) {
+  var d = ( state !== undefined ) ? !state : hasClass( elem, c );
+  var fn = d ? removeClass : addClass;
   fn( elem, c );
 }
 


### PR DESCRIPTION
First of all, thanks for the code! I have been using this library for a while for cases where including a full jQuery or equivalent is too heavyweight.

For a recent project that I work on, there is an extensive amount of UI-related code that does class toggling based on some Booleans. Something like:

``` js
if (someCondition) {
  classie.removeClass(elem, 'some-class');
} else {
  classie.addClass(elem, 'some-class');
}
```

Thus, in a local version that we use here, we have modified the `toggle`/`toggleClass` to include a third parameter `state`, making it `toggleClass(elem, c, state)`. So the code above becomes something like:

``` js
classie.toggleClass(elem, 'some-class', someCondition);
```

This pattern is similar to the [`toggleClass` implementation](http://api.jquery.com/toggleClass) in jQuery, which [allows a call like `$(elem).toggleClass(someCondition);`](http://api.jquery.com/toggleClass/#toggleClass-className-state).

Please see if you would like this in the official releases as well. Thanks! :)
